### PR TITLE
Remove unnecessary config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,8 +23,6 @@ framework:
 # Contao configuration
 contao:
     prepend_locale: "%prepend_locale%"
-    url_suffix:     "%url_suffix%"
-    upload_path:    "%upload_path%"
     encryption_key: "%kernel.secret%"
 
 # Twig configuration

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -14,7 +14,5 @@ parameters:
     mailer_password:   ~
 
     prepend_locale:    false
-    url_suffix:        .html
-    upload_path:       files
 
     secret:            ThisTokenIsNotSoSecretChangeIt


### PR DESCRIPTION
The config parameter for `contao.url_suffix` and `contao.upload_path` are unnecessary in the `config.yml`. The current default values are already given by the default values of the container config (see https://github.com/contao/core-bundle/blob/develop/src/DependencyInjection/Configuration.php#L38-L43).

Having them available in `parameters.yml` and letting the user decide **on each installation** is also totally unnecessary imho, because they are not changed most of the time.

If someone really wants to add them, they can simply add the config to their `app/config.yml`.
