### PR TITLE
[RTM] Add legacy packages repository to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,11 @@
             "Contao\\CoreBundle\\Composer\\ScriptHandler::addDirectories",
             "Contao\\CoreBundle\\Composer\\ScriptHandler::generateSymlinks"
         ]
-    }
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://legacy-packages-via.contao-community-alliance.org/"
+        }
+    ]
 }


### PR DESCRIPTION
Add the legacy packages repository to the standard edition as discussed at the dev meeting. This should only be merged once the composer plugin for Contao 4 is ready.

/cc @discordier 
