### PR TITLE
Random secret must be generated after packages are installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,10 +47,8 @@
         "symfony-assets-install": "relative"
     },
     "scripts": {
-        "pre-install-cmd": [
-            "Contao\\CoreBundle\\Composer\\ScriptHandler::generateRandomSecret"
-        ],
         "post-install-cmd": [
+            "Contao\\CoreBundle\\Composer\\ScriptHandler::generateRandomSecret",
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
@@ -59,6 +57,7 @@
             "Contao\\CoreBundle\\Composer\\ScriptHandler::generateSymlinks"
         ],
         "post-update-cmd": [
+            "Contao\\CoreBundle\\Composer\\ScriptHandler::generateRandomSecret",
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",


### PR DESCRIPTION
The current random secret does not work for two reasons:
1. It is only run for `composer install`, but not for `composer update`
2. It requires the `random_bytes` method which is loaded by composer, so it can't run before package installation.
