### PR TITLE
[RFC] Exclude Contao tables from Doctrine schema

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -37,13 +37,14 @@ doctrine:
         default_connection: default
         connections:
             default:
-                driver:   pdo_mysql
-                host:     "%database_host%"
-                port:     "%database_port%"
-                user:     "%database_user%"
-                password: "%database_password%"
-                dbname:   "%database_name%"
-                charset:  UTF8
+                driver:        pdo_mysql
+                host:          "%database_host%"
+                port:          "%database_port%"
+                user:          "%database_user%"
+                password:      "%database_password%"
+                dbname:        "%database_name%"
+                charset:       UTF8
+                schema_filter: ~^(?!tl_)~
 
 # SwiftMailer configuration
 swiftmailer:


### PR DESCRIPTION
Adding `schema_filter` will tell Doctrine migrations to ignore all tables starting with `tl_`. This would also allow us to start using Doctrine entities and use Doctrine migrations in the install tool, if the database markup is set in the entities and not the DCA.

I'm not sure about side effects with my Doctrine integration yet, so this should just be something to discuss.
