### PR TITLE
[WIP] Prevent loading of InstallationBundle in production

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -33,7 +33,6 @@ class AppKernel extends Kernel
             new Contao\CalendarBundle\ContaoCalendarBundle(),
             new Contao\CommentsBundle\ContaoCommentsBundle(),
             new Contao\FaqBundle\ContaoFaqBundle(),
-            new Contao\InstallationBundle\ContaoInstallationBundle(),
             new Contao\ListingBundle\ContaoListingBundle(),
             new Contao\NewsBundle\ContaoNewsBundle(),
             new Contao\NewsletterBundle\ContaoNewsletterBundle(),
@@ -43,6 +42,7 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+            $bundles[] = new Contao\InstallationBundle\ContaoInstallationBundle();
         }
 
         return $bundles;

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,5 +1,2 @@
-ContaoInstallationBundle:
-    resource: "@ContaoInstallationBundle/Resources/config/routing.yml"
-
 ContaoCoreBundle:
     resource: "@ContaoCoreBundle/Resources/config/routing.yml"

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -6,5 +6,8 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
+ContaoInstallationBundle:
+    resource: "@ContaoInstallationBundle/Resources/config/routing.yml"
+
 _main:
     resource: routing.yml

--- a/web/install.php
+++ b/web/install.php
@@ -18,7 +18,7 @@ error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED);
  */
 $loader = require __DIR__.'/../app/autoload.php';
 
-$kernel = new InstallationKernel('prod', false);
+$kernel = new InstallationKernel('dev', false);
 $kernel->loadClassCache();
 
 // Handle the request


### PR DESCRIPTION
The `InstallationBundle` is loaded into the application on every page rendering. I can't see a reason for this, so here's a PR to only load it in `dev`.