### PR TITLE
add database_driver to parameters.yml.dist

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -7,6 +7,7 @@ parameters:
     database_user:     ~
     database_password: ~
     database_name:     ~
+    database_driver:   pdo_mysql
 
     mailer_transport:  mail
     mailer_host:       127.0.0.1


### PR DESCRIPTION
Contao uses
```php
\System::getContainer()->getParameter('database_driver')
```
here: [/src/Resources/contao/library/Contao/Database.php#L78](https://github.com/contao/core-bundle/blob/4.3.7/src/Resources/contao/library/Contao/Database.php#L78)

This call will fail with
```
Fatal error: Uncaught Symfony\Component\DependencyInjection\Exception\InvalidArgumentException:
The parameter "database_driver" must be defined. in /var/cache/prod/appProdProjectContainer.php:3379
```
if no `database_driver` variable is defined in the `parameters.yml`. See https://github.com/contao/core-bundle/issues/733